### PR TITLE
session clearing must be in IdentityKeyStore implementation

### DIFF
--- a/AxolotlKit/Classes/SessionCipher.m
+++ b/AxolotlKit/Classes/SessionCipher.m
@@ -124,9 +124,7 @@ static dispatch_queue_t _sessionCipherDispatchQueue;
                                      userInfo:@{}];
     }
 
-    if ([self.identityKeyStore saveRemoteIdentity:sessionState.remoteIdentityKey recipientId:self.recipientId]) {
-        [sessionRecord removePreviousSessionStates];
-    }
+    [self.identityKeyStore saveRemoteIdentity:sessionState.remoteIdentityKey recipientId:self.recipientId];
 
     NSData *ciphertextBody = [AES_CBC encryptCBCMode:paddedMessage withKey:messageKeys.cipherKey withIV:messageKeys.iv];
 
@@ -202,11 +200,8 @@ static dispatch_queue_t _sessionCipherDispatchQueue;
                                      userInfo:@{}];
     }
 
-    if ([self.identityKeyStore saveRemoteIdentity:sessionRecord.sessionState.remoteIdentityKey
-                                      recipientId:self.recipientId]) {
-        [sessionRecord removePreviousSessionStates];
-    }
-
+    [self.identityKeyStore saveRemoteIdentity:sessionRecord.sessionState.remoteIdentityKey
+                                  recipientId:self.recipientId];
     [self.sessionStore storeSession:self.recipientId deviceId:self.deviceId session:sessionRecord];
     
     return plaintext;

--- a/AxolotlKit/Classes/Sessions/SessionBuilder.m
+++ b/AxolotlKit/Classes/Sessions/SessionBuilder.m
@@ -141,14 +141,7 @@ const int kPreKeyOfLastResortId = 0xFFFFFF;
             break;
     }
 
-    BOOL previousIdentityExisted =
-        [self.identityStore saveRemoteIdentity:theirIdentityKey recipientId:self.recipientId];
-    if (previousIdentityExisted) {
-        DDLogInfo(@"%@ PKWM removing previous session states for changed identity for recipient:%@",
-            self.tag,
-            self.recipientId);
-        [sessionRecord removePreviousSessionStates];
-    }
+    [self.identityStore saveRemoteIdentity:theirIdentityKey recipientId:self.recipientId];
 
     return unSignedPrekeyId;
 }


### PR DESCRIPTION
Trying to do it in the protocol will not work with multiple devices,
because we'll only archive the session of the first sending device.

see also: https://github.com/WhisperSystems/SignalServiceKit/pull/283

PTAL @charlesmchen 